### PR TITLE
Added per-app "discard ongoing notifications" option

### DIFF
--- a/app/src/main/java/com/abhijitvalluri/android/fitnotifications/AppSettingsActivity.java
+++ b/app/src/main/java/com/abhijitvalluri/android/fitnotifications/AppSettingsActivity.java
@@ -47,6 +47,7 @@ public class AppSettingsActivity extends AppCompatActivity implements TimePicker
     public static final String STATE_STOP_TIME_HOUR = "stopTimeHour";
     public static final String STATE_STOP_TIME_MINUTE = "stopTimeMinute";
     public static final String STATE_DISCARD_EMPTY_NOTIFICATIONS = "discardEmptyNotifications";
+    public static final String STATE_DISCARD_ONGOING_NOTIFICATIONS = "discardOngoingNotifications";
     public static final String STATE_ALL_DAY_SCHEDULE = "allDaySchedule";
 
     private static final String DIALOG_TIME = "dialogTime";
@@ -62,6 +63,7 @@ public class AppSettingsActivity extends AppCompatActivity implements TimePicker
     private int mStopTimeHour;
     private int mStopTimeMinute;
     private boolean mDiscardEmptyNotifications;
+    private boolean mDiscardOngoingNotifications;
     private boolean mAllDaySchedule;
 
     @Override
@@ -70,6 +72,7 @@ public class AppSettingsActivity extends AppCompatActivity implements TimePicker
         setContentView(R.layout.activity_app_settings);
 
         Switch discardEmptySwitch;
+        Switch discardOngoingSwitch;
         Switch allDaySwitch;
 
         mFilterText = (EditText) findViewById(R.id.filter_text);
@@ -77,6 +80,7 @@ public class AppSettingsActivity extends AppCompatActivity implements TimePicker
         mStopTimeButton = (Button) findViewById(R.id.stop_time);
         mNextDay = (TextView) findViewById(R.id.next_day);
         discardEmptySwitch = (Switch) findViewById(R.id.discard_empty);
+        discardOngoingSwitch = (Switch) findViewById(R.id.discard_ongoing);
         allDaySwitch = (Switch) findViewById(R.id.all_day);
 
         mFilterText.setHorizontallyScrolling(false);
@@ -89,6 +93,7 @@ public class AppSettingsActivity extends AppCompatActivity implements TimePicker
             mStopTimeHour = mAppSelection.getStopTimeHour();
             mStopTimeMinute = mAppSelection.getStopTimeMinute();
             mDiscardEmptyNotifications = mAppSelection.isDiscardEmptyNotifications();
+            mDiscardOngoingNotifications = mAppSelection.isDiscardOngoingNotifications();
             mAllDaySchedule = mAppSelection.isAllDaySchedule();
         } else {
             mAppSelection = savedInstanceState.getParcelable(STATE_APP_SELECTION);
@@ -97,10 +102,12 @@ public class AppSettingsActivity extends AppCompatActivity implements TimePicker
             mStopTimeHour = savedInstanceState.getInt(STATE_STOP_TIME_HOUR);
             mStopTimeMinute = savedInstanceState.getInt(STATE_STOP_TIME_MINUTE);
             mDiscardEmptyNotifications = savedInstanceState.getBoolean(STATE_DISCARD_EMPTY_NOTIFICATIONS);
+            mDiscardOngoingNotifications = savedInstanceState.getBoolean(STATE_DISCARD_ONGOING_NOTIFICATIONS);
             mAllDaySchedule = savedInstanceState.getBoolean(STATE_ALL_DAY_SCHEDULE);
         }
 
         discardEmptySwitch.setChecked(mDiscardEmptyNotifications);
+        discardOngoingSwitch.setChecked(mDiscardOngoingNotifications);
         setTitle(mAppSelection.getAppName());
         mFilterText.setText(mAppSelection.getFilterText());
 
@@ -111,6 +118,13 @@ public class AppSettingsActivity extends AppCompatActivity implements TimePicker
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 mDiscardEmptyNotifications = isChecked;
+            }
+        });
+
+        discardOngoingSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                mDiscardOngoingNotifications = isChecked;
             }
         });
 
@@ -193,6 +207,7 @@ public class AppSettingsActivity extends AppCompatActivity implements TimePicker
         outState.putInt(STATE_STOP_TIME_MINUTE, mStopTimeMinute);
         outState.putBoolean(STATE_DISCARD_EMPTY_NOTIFICATIONS, mDiscardEmptyNotifications);
         outState.putBoolean(STATE_ALL_DAY_SCHEDULE, mAllDaySchedule);
+        outState.putBoolean(STATE_DISCARD_ONGOING_NOTIFICATIONS, mDiscardOngoingNotifications);
 
         super.onSaveInstanceState(outState);
     }
@@ -216,6 +231,7 @@ public class AppSettingsActivity extends AppCompatActivity implements TimePicker
         mAppSelection.setStopTimeHour(mStopTimeHour);
         mAppSelection.setStopTimeMinute(mStopTimeMinute);
         mAppSelection.setDiscardEmptyNotifications(mDiscardEmptyNotifications);
+        mAppSelection.setDiscardOngoingNotifications(mDiscardOngoingNotifications);
         mAppSelection.setAllDaySchedule(mAllDaySchedule);
 
         Intent intent = new Intent();

--- a/app/src/main/java/com/abhijitvalluri/android/fitnotifications/database/AppSelectionCursorWrapper.java
+++ b/app/src/main/java/com/abhijitvalluri/android/fitnotifications/database/AppSelectionCursorWrapper.java
@@ -41,6 +41,7 @@ public class AppSelectionCursorWrapper extends CursorWrapper {
         int stopTimeHour      = getInt(getColumnIndex(AppChoiceTable.Cols.STOP_TIME_HOUR));
         int stopTimeMinute    = getInt(getColumnIndex(AppChoiceTable.Cols.STOP_TIME_MINUTE));
         int discardEmptyNotif = getInt(getColumnIndex(AppChoiceTable.Cols.DISCARD_EMPTY_NOTIFICATIONS));
+        int discardOngoingNtf = getInt(getColumnIndex(AppChoiceTable.Cols.DISCARD_ONGOING_NOTIFICATIONS));
         int allDaySchedule    = getInt(getColumnIndex(AppChoiceTable.Cols.ALL_DAY_SCHEDULE));
 
         return new AppSelection(appPackageName,
@@ -52,6 +53,7 @@ public class AppSelectionCursorWrapper extends CursorWrapper {
                                 stopTimeHour,
                                 stopTimeMinute,
                                 discardEmptyNotif != 0,
+                                discardOngoingNtf != 0,
                                 allDaySchedule != 0);
     }
 }

--- a/app/src/main/java/com/abhijitvalluri/android/fitnotifications/database/AppSelectionDbHelper.java
+++ b/app/src/main/java/com/abhijitvalluri/android/fitnotifications/database/AppSelectionDbHelper.java
@@ -26,7 +26,7 @@ import com.abhijitvalluri.android.fitnotifications.database.AppSelectionDbSchema
  * Helper class for the Database
  */
 public class AppSelectionDbHelper extends SQLiteOpenHelper {
-    private static final int VERSION = 3;
+    private static final int VERSION = 4;
     private static final String DATABASE_NAME = "fitNotificationAppSelection.db";
 
     public AppSelectionDbHelper(Context context) {
@@ -46,6 +46,7 @@ public class AppSelectionDbHelper extends SQLiteOpenHelper {
                 AppChoiceTable.Cols.STOP_TIME_HOUR + ", " +
                 AppChoiceTable.Cols.STOP_TIME_MINUTE + ", " +
                 AppChoiceTable.Cols.DISCARD_EMPTY_NOTIFICATIONS + ", " +
+                AppChoiceTable.Cols.DISCARD_ONGOING_NOTIFICATIONS + ", " +
                 AppChoiceTable.Cols.ALL_DAY_SCHEDULE +
                 ")"
         );
@@ -67,10 +68,17 @@ public class AppSelectionDbHelper extends SQLiteOpenHelper {
             db.execSQL("alter table " + AppChoiceTable.NAME + " add column " +
                     AppChoiceTable.Cols.DISCARD_EMPTY_NOTIFICATIONS + " INTEGER NOT NULL DEFAULT 0;");
             db.execSQL("alter table " + AppChoiceTable.NAME + " add column " +
+                    AppChoiceTable.Cols.DISCARD_ONGOING_NOTIFICATIONS + " INTEGER NOT NULL DEFAULT 1;");
+            db.execSQL("alter table " + AppChoiceTable.NAME + " add column " +
                     AppChoiceTable.Cols.ALL_DAY_SCHEDULE + " INTEGER NOT NULL DEFAULT 1;");
         } else if (oldVersion == 2 && newVersion == VERSION) {
             db.execSQL("alter table " + AppChoiceTable.NAME + " add column " +
                     AppChoiceTable.Cols.ALL_DAY_SCHEDULE + " INTEGER NOT NULL DEFAULT 1;");
+            db.execSQL("alter table " + AppChoiceTable.NAME + " add column " +
+                    AppChoiceTable.Cols.DISCARD_ONGOING_NOTIFICATIONS + " INTEGER NOT NULL DEFAULT 1;");
+        } else if (oldVersion == 3 && newVersion == VERSION) {
+            db.execSQL("alter table " + AppChoiceTable.NAME + " add column " +
+                    AppChoiceTable.Cols.DISCARD_ONGOING_NOTIFICATIONS + " INTEGER NOT NULL DEFAULT 1;");
         }
     }
 }

--- a/app/src/main/java/com/abhijitvalluri/android/fitnotifications/database/AppSelectionDbSchema.java
+++ b/app/src/main/java/com/abhijitvalluri/android/fitnotifications/database/AppSelectionDbSchema.java
@@ -33,6 +33,7 @@ public class AppSelectionDbSchema {
             public static final String STOP_TIME_HOUR = "stopTimeHour";
             public static final String STOP_TIME_MINUTE = "stopTimeMinute";
             public static final String DISCARD_EMPTY_NOTIFICATIONS = "discardEmptyNotifications";
+            public static final String DISCARD_ONGOING_NOTIFICATIONS = "discardOngoingNotifications";
             public static final String ALL_DAY_SCHEDULE = "allDaySchedule";
         }
     }

--- a/app/src/main/java/com/abhijitvalluri/android/fitnotifications/models/AppSelection.java
+++ b/app/src/main/java/com/abhijitvalluri/android/fitnotifications/models/AppSelection.java
@@ -33,6 +33,7 @@ public class AppSelection implements Parcelable {
     private int mStopTimeHour;
     private int mStopTimeMinute;
     private boolean mDiscardEmptyNotifications;
+    private boolean mDiscardOngoingNotifications;
     private boolean mAllDaySchedule;
 
     public AppSelection(String appPackageName, String appName) {
@@ -44,6 +45,7 @@ public class AppSelection implements Parcelable {
         mStopTimeHour = 23;
         mStopTimeMinute = 59;
         mAllDaySchedule = true;
+        mDiscardOngoingNotifications = true;
     }
 
     public AppSelection(String appPackageName,
@@ -55,6 +57,7 @@ public class AppSelection implements Parcelable {
                         int stopTimeHour,
                         int stopTimeMinute,
                         boolean discardEmptyNotifications,
+                        boolean discardOngoingNotifications,
                         boolean allDaySchedule) {
         mAppPackageName = appPackageName;
         mAppName = appName;
@@ -65,6 +68,7 @@ public class AppSelection implements Parcelable {
         mStopTimeHour = stopTimeHour;
         mStopTimeMinute = stopTimeMinute;
         mDiscardEmptyNotifications = discardEmptyNotifications;
+        mDiscardOngoingNotifications = discardOngoingNotifications;
         mAllDaySchedule = allDaySchedule;
     }
 
@@ -132,6 +136,14 @@ public class AppSelection implements Parcelable {
         mDiscardEmptyNotifications = discardEmptyNotifications;
     }
 
+    public boolean isDiscardOngoingNotifications() {
+        return mDiscardOngoingNotifications;
+    }
+
+    public void setDiscardOngoingNotifications(boolean discardOngoingNotifications) {
+        mDiscardOngoingNotifications = discardOngoingNotifications;
+    }
+
     public boolean isAllDaySchedule() {
         return mAllDaySchedule;
     }
@@ -159,6 +171,12 @@ public class AppSelection implements Parcelable {
         mStopTimeMinute = in.readInt();
         mDiscardEmptyNotifications = in.readByte() != 0x00;
         mAllDaySchedule = in.readByte() != 0x00;
+        if (in.dataAvail() > 0) {
+            mDiscardOngoingNotifications = in.readByte() != 0x00;
+        }
+        else {
+            mDiscardOngoingNotifications = true;
+        }
     }
 
     @Override
@@ -178,6 +196,7 @@ public class AppSelection implements Parcelable {
         dest.writeInt(mStopTimeMinute);
         dest.writeByte((byte) (mDiscardEmptyNotifications ? 0x01 : 0x00));
         dest.writeByte((byte) (mAllDaySchedule ? 0x01 : 0x00));
+        dest.writeByte((byte) (mDiscardOngoingNotifications ? 0x01 : 0x00));
     }
 
     @SuppressWarnings("unused")

--- a/app/src/main/java/com/abhijitvalluri/android/fitnotifications/services/NLService.java
+++ b/app/src/main/java/com/abhijitvalluri/android/fitnotifications/services/NLService.java
@@ -190,17 +190,6 @@ public class NLService extends NotificationListenerService {
         final String appPackageName = sbn.getPackageName();
         Bundle extras = notification.extras;
 
-        // DISREGARD SPAMMY NOTIFICATIONS
-        if ((notification.flags & Notification.FLAG_ONGOING_EVENT) > 0) {
-            // Discard ongoing notifications
-            // TODO: Nothing else apart from this is consistent.
-            // I tried to see InboxStyle notifications vs. not and that did not help
-            // Not all use the EXTRA_SUMMARY_GROUP correctly either
-            // Perhaps best option is to allow users to custom discard useless
-            // messages via a string match
-            return;
-        }
-
         if (!appNotificationsActive(appPackageName)) {
             return;
         }
@@ -217,13 +206,26 @@ public class NLService extends NotificationListenerService {
 
         String filterText = null;
         boolean discardEmptyNotifications = false;
+        boolean discardOngoingNotifications = true;
 
         {
             AppSelection appSelection = AppSelectionsStore.get(this).getAppSelection(appPackageName);
             if (appSelection != null) {
                 filterText = appSelection.getFilterText().trim();
                 discardEmptyNotifications = appSelection.isDiscardEmptyNotifications();
+                discardOngoingNotifications = appSelection.isDiscardOngoingNotifications();
             }
+        }
+
+        // DISREGARD SPAMMY NOTIFICATIONS
+        if (discardOngoingNotifications && (notification.flags & Notification.FLAG_ONGOING_EVENT) > 0) {
+            // Discard ongoing notifications
+            // TODO: Nothing else apart from this is consistent.
+            // I tried to see InboxStyle notifications vs. not and that did not help
+            // Not all use the EXTRA_SUMMARY_GROUP correctly either
+            // Perhaps best option is to allow users to custom discard useless
+            // messages via a string match
+            return;
         }
 
         CharSequence notificationTitle = extras.getCharSequence(Notification.EXTRA_TITLE);

--- a/app/src/main/java/com/abhijitvalluri/android/fitnotifications/utils/AppSelectionsStore.java
+++ b/app/src/main/java/com/abhijitvalluri/android/fitnotifications/utils/AppSelectionsStore.java
@@ -171,6 +171,7 @@ public class AppSelectionsStore {
         values.put(AppChoiceTable.Cols.STOP_TIME_HOUR, appSelection.getStopTimeHour());
         values.put(AppChoiceTable.Cols.STOP_TIME_MINUTE, appSelection.getStopTimeMinute());
         values.put(AppChoiceTable.Cols.DISCARD_EMPTY_NOTIFICATIONS, appSelection.isDiscardEmptyNotifications() ? 1 : 0);
+        values.put(AppChoiceTable.Cols.DISCARD_ONGOING_NOTIFICATIONS, appSelection.isDiscardOngoingNotifications() ? 1 : 0);
         values.put(AppChoiceTable.Cols.ALL_DAY_SCHEDULE, appSelection.isAllDaySchedule() ? 1 : 0);
 
         return values;

--- a/app/src/main/res/layout/activity_app_settings.xml
+++ b/app/src/main/res/layout/activity_app_settings.xml
@@ -59,6 +59,16 @@
             android:text="@string/discard_empty_notifications"
             android:id="@+id/discard_empty"/>
 
+        <Switch
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:textAppearance="?android:attr/textAppearanceLarge"
+            android:text="@string/discard_ongoing_notifications"
+            android:id="@+id/discard_ongoing"
+            android:checked="true" />
+
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,6 +215,7 @@
     <string name="filter_heading">Filter Text</string>
     <string name="filter_desc">All notifications from this app containing the specified text will be filtered out and not displayed on your Fitbit. Separate multiple patterns with a semicolon (;).</string>
     <string name="discard_empty_notifications">Discard empty notifications</string>
+    <string name="discard_ongoing_notifications">Discard ongoing notifications</string>
     <string name="schedule_heading">Notification Schedule</string>
     <string name="schedule_desc">Notifications from this app will only be forwarded to your Fitbit from the specified start time till the specified end time.</string>
     <string name="start_time_heading">Start from:</string>


### PR DESCRIPTION
This allows ongoing notifications to be relayed for chosen apps -
allowing things like "now playing" notifications from Spotify.

This new option defaults to "on" so as to maintain the existing
"non-spammy" behaviour, so a user has to explicitly turn off the switch
to allow ongoing notifications to be relayed.

--

Would appreciate a code review of this, as it's been a while since I've done any serious Android stuff - especially around the db upgrade stuff!